### PR TITLE
Fix wrong plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ plugins {
 }
 
 group 'de.codecrafter47.taboverlay'
-version '0.4-SNAPSHOT'
+version '1.0.0'
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'


### PR DESCRIPTION
On spigot is the plugin listed as version `1.0.0` and when downloading the jar is it also called `AdvancedTabOverlay-1.0.0.jar`, but the plugin.yml has it listed as 0.4-SNAPSHOT cause by the version in the build.gradle being wrong.

This PR fixes that mistake.